### PR TITLE
Updated url in config.properties for dl4j-labs and dl4j-cv-labs by re…

### DIFF
--- a/dl4j-cv-labs/src/main/resources/config.properties
+++ b/dl4j-cv-labs/src/main/resources/config.properties
@@ -9,28 +9,28 @@ dl4j_home.export-images=.deeplearning4j/segmentation-export-images
 
 
 #dog breed dataset link
-dataset.dogbreed.url=https://archive.org/download/training-datasets/dog-breed-identification.zip
+dataset.dogbreed.url = https://s3.eu-central-1.wasabisys.com/certifai/Training%20datasets/dog-breed-identification.zip
 dataset.dogbreed.hash=BC738569CC7CF063D43F4AF4649E7273
 
 #segmentation cell image dataset link
-dataset.segmentationCell.url=https://archive.org/download/training-datasets/data-science-bowl-2018-2.zip
+dataset.segmentationCell.url = https://s3.eu-central-1.wasabisys.com/certifai/Training%20datasets/data-science-bowl-2018-2.zip
 dataset.segmentationCell.hash=1646ECBF1AC524C22E1918168B99B81B
 
 #segmentation car image dataset link
-dataset.segmentationCar.url=https://archive.org/download/training-datasets/carvana-masking-challenge.zip
+dataset.segmentationCar.url = https://s3.eu-central-1.wasabisys.com/certifai/Training%20datasets/carvana-masking-challenge.zip
 dataset.segmentationCar.hash=0c7305d1cad68b923830958297a84eb2
 
 #fruits dataset link
-dataset.fruits.url=https://archive.org/download/training-datasets/fruits.zip
+dataset.fruits.url = https://s3.eu-central-1.wasabisys.com/certifai/Training%20datasets/fruits.zip
 dataset.fruits.hash=5F78E3E7AFE7220DE5EECA316304A203
 
 #metal defects dataset link
-dataset.metaldefects.url=https://archive.org/download/training-datasets/metal-defects.zip
+dataset.metaldefects.url = https://s3.eu-central-1.wasabisys.com/certifai/Training%20datasets/metal-defects.zip
 dataset.metaldefects.hash=608237A4E6647B315D8464B4C2B74FC1
 
-models.metaldefectsdetector.url=https://archive.org/download/pretrainedmodels/Pretrained_MetalSurfaceDefects_yolov2.zip
+models.metaldefectsdetector.url = https://s3.eu-central-1.wasabisys.com/certifai/Pretrained%20Models/Pretrained_MetalSurfaceDefects_yolov2.zip
 models.metaldefectsdetector.hash=C5EB2A23255DC2ED0A3D482D9E6A4E0C
 
 #face recognition video sample
-dataset.sample.url=https://archive.org/download/sample_20200909/sample.mp4
+dataset.sample.url = https://s3.eu-central-1.wasabisys.com/certifai/sample/sample.mp4
 dataset.sample.hash=13fdbb937cf3a5639478b937f92cc507

--- a/dl4j-labs/src/main/resources/config.properties
+++ b/dl4j-labs/src/main/resources/config.properties
@@ -1,4 +1,4 @@
-#dl4j-cv-labs properties
+#dl4j-labs properties
 
 #data directory
 dl4j_home.data=.deeplearning4j/data

--- a/dl4j-labs/src/main/resources/config.properties
+++ b/dl4j-labs/src/main/resources/config.properties
@@ -3,8 +3,8 @@
 #data directory
 dl4j_home.data=.deeplearning4j/data
 #plant seed lings classification dataset link
-dataset.plant.seed.url=https://archive.org/download/training-datasets/plant-seedlings-classification.zip
+dataset.plant.seed.url = https://s3.eu-central-1.wasabisys.com/certifai/Training%20datasets/plant-seedlings-classification.zip
 dataset.plant.seed.hash=B92EB0E4AD468599FDB61D3F151F2A32
 #ridership demand dataset link
-dataset.ridership.demand.url=https://archive.org/download/training-datasets/ridership.zip
+dataset.ridership.demand.url = https://s3.eu-central-1.wasabisys.com/certifai/Training%20datasets/ridership.zip
 dataset.ridership.demand.hash=83f3d41fbc3a38afecf98d868c33e549


### PR DESCRIPTION
…placing the url from archive.org to wasabi

## Description

The storage of data have been migrated from archive.org to wasabi. Thus, the url in config.properties for both dl4j-labs and dl4j-cv-labs have been updated. 

Fixes # (issue)

## Tested on 
- [X ] Windows  
- [ ] Linux Ubuntu  
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

Assign a reviewer to review your code.
