### PR TITLE
Ky histogram equalization patch

### DIFF
--- a/dl4j-cv-labs/src/main/java/ai/certifai/solution/image_processing/HistogramEqualization.java
+++ b/dl4j-cv-labs/src/main/java/ai/certifai/solution/image_processing/HistogramEqualization.java
@@ -15,7 +15,7 @@
  */
 package ai.certifai.solution.image_processing;
 
-import global.skymind.solution.image_processing.utils.histogram.Histogram1DJava;
+import ai.certifai.solution.image_processing.utils.histogram.Histogram1DJava;
 import org.bytedeco.opencv.opencv_core.Mat;
 import org.nd4j.common.io.ClassPathResource;
 
@@ -45,6 +45,7 @@ public class HistogramEqualization {
         String imgpath = new ClassPathResource("image_processing/x-ray.jpeg").getFile().getAbsolutePath();
 
         Mat src = imread(imgpath, IMREAD_GRAYSCALE);
+
         Mat dest = new Mat();
         Histogram1DJava h = new Histogram1DJava();
 

--- a/dl4j-cv-labs/src/main/java/ai/certifai/solution/image_processing/utils/histogram/Histogram1DJava.java
+++ b/dl4j-cv-labs/src/main/java/ai/certifai/solution/image_processing/utils/histogram/Histogram1DJava.java
@@ -33,7 +33,8 @@ import static org.bytedeco.opencv.global.opencv_imgproc.calcHist;
  */
 public class Histogram1DJava {
     private int numberOfBins = 256;
-    private IntPointer channels = new IntPointer(1);
+    int[] channels_arr = new int[]{0, 1, 2};
+    private IntPointer channels = new IntPointer(channels_arr);
     private Float _minRange = 0.0f;
     private Float _maxRange = 255.0f;
 

--- a/dl4j-cv-labs/src/main/java/ai/certifai/solution/image_processing/utils/histogram/Histogram1DJava.java
+++ b/dl4j-cv-labs/src/main/java/ai/certifai/solution/image_processing/utils/histogram/Histogram1DJava.java
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package global.skymind.training.image_processing.utils.histogram;
+package ai.certifai.solution.image_processing.utils.histogram;
 
 import org.bytedeco.javacpp.FloatPointer;
 import org.bytedeco.javacpp.IntPointer;
@@ -33,7 +33,7 @@ import static org.bytedeco.opencv.global.opencv_imgproc.calcHist;
  */
 public class Histogram1DJava {
     private int numberOfBins = 256;
-    private IntPointer channels = new IntPointer(3);
+    private IntPointer channels = new IntPointer(1);
     private Float _minRange = 0.0f;
     private Float _maxRange = 255.0f;
 

--- a/dl4j-cv-labs/src/main/java/ai/certifai/training/image_processing/HistogramEqualization.java
+++ b/dl4j-cv-labs/src/main/java/ai/certifai/training/image_processing/HistogramEqualization.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  * */
 
 public class HistogramEqualization {
-    public static void main () throws IOException {
+    public static void main (String[] args) throws IOException {
 
         /*
         *

--- a/dl4j-cv-labs/src/main/java/ai/certifai/training/image_processing/utils/histogram/Histogram1DJava.java
+++ b/dl4j-cv-labs/src/main/java/ai/certifai/training/image_processing/utils/histogram/Histogram1DJava.java
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package global.skymind.solution.image_processing.utils.histogram;
+package ai.certifai.training.image_processing.utils.histogram;
 
 import org.bytedeco.javacpp.FloatPointer;
 import org.bytedeco.javacpp.IntPointer;
@@ -33,7 +33,7 @@ import static org.bytedeco.opencv.global.opencv_imgproc.calcHist;
  */
 public class Histogram1DJava {
     private int numberOfBins = 256;
-    private IntPointer channels = new IntPointer(3);
+    private IntPointer channels = new IntPointer(new int[]{0, 1, 2});
     private Float _minRange = 0.0f;
     private Float _maxRange = 255.0f;
 


### PR DESCRIPTION
## Description

Changed the input of channels for Histogram1D.java file in `utils `folder from integer to integer array. This fixed the issue reported in https://github.com/CertifaiAI/TrainingLabs/issues/147 and was tested. No other dependencies are required to changed.

Credits goes to @jacklynlxq for figuring out the solution above.

Also refactored the package path.

Fixes # (https://github.com/CertifaiAI/TrainingLabs/issues/147)

## Tested on 
- [X] Windows  
- [ ] Linux Ubuntu  
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

