### PR TITLE
custom voc label provider

### DIFF
--- a/dl4j-cv-labs/pom.xml
+++ b/dl4j-cv-labs/pom.xml
@@ -84,6 +84,11 @@
             <version>${nd4j.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+        </dependency>
         <!--Uncomment to enable cudnn-->
         <!--<dependency>
             <groupId>org.deeplearning4j</groupId>

--- a/dl4j-cv-labs/src/main/java/ai/certifai/solution/object_detection/AvocadoBananaDetector/FruitDataSetIterator.java
+++ b/dl4j-cv-labs/src/main/java/ai/certifai/solution/object_detection/AvocadoBananaDetector/FruitDataSetIterator.java
@@ -18,12 +18,12 @@
 package ai.certifai.solution.object_detection.AvocadoBananaDetector;
 
 import ai.certifai.Helper;
+import ai.certifai.utilities.VocLabelProvider;
 import org.apache.commons.io.FileUtils;
 import org.datavec.api.split.FileSplit;
 import org.datavec.api.split.InputSplit;
 import org.datavec.image.loader.NativeImageLoader;
 import org.datavec.image.recordreader.objdetect.ObjectDetectionRecordReader;
-import org.datavec.image.recordreader.objdetect.impl.VocLabelProvider;
 import org.deeplearning4j.datasets.datavec.RecordReaderDataSetIterator;
 import org.nd4j.common.util.ArchiveUtils;
 import org.nd4j.linalg.dataset.api.preprocessor.ImagePreProcessingScaler;

--- a/dl4j-cv-labs/src/main/java/ai/certifai/solution/object_detection/MetalDefectsDetector/MetalDefectDataSetIterator.java
+++ b/dl4j-cv-labs/src/main/java/ai/certifai/solution/object_detection/MetalDefectsDetector/MetalDefectDataSetIterator.java
@@ -18,12 +18,12 @@
 package ai.certifai.solution.object_detection.MetalDefectsDetector;
 
 import ai.certifai.Helper;
+import ai.certifai.utilities.VocLabelProvider;
 import org.apache.commons.io.FileUtils;
 import org.datavec.api.split.FileSplit;
 import org.datavec.api.split.InputSplit;
 import org.datavec.image.loader.NativeImageLoader;
 import org.datavec.image.recordreader.objdetect.ObjectDetectionRecordReader;
-import org.datavec.image.recordreader.objdetect.impl.VocLabelProvider;
 import org.deeplearning4j.datasets.datavec.RecordReaderDataSetIterator;
 import org.nd4j.common.util.ArchiveUtils;
 import org.nd4j.linalg.dataset.api.preprocessor.ImagePreProcessingScaler;

--- a/dl4j-cv-labs/src/main/java/ai/certifai/training/cv2_classification/Demo.java
+++ b/dl4j-cv-labs/src/main/java/ai/certifai/training/cv2_classification/Demo.java
@@ -1,0 +1,24 @@
+package ai.certifai.training.cv2_classification;/*
+ *
+ *  * ******************************************************************************
+ *  *  * Copyright (c) 2019 Skymind AI Bhd.
+ *  *  * Copyright (c) 2020 CertifAI Sdn. Bhd.
+ *  *  *
+ *  *  * This program and the accompanying materials are made available under the
+ *  *  * terms of the Apache License, Version 2.0 which is available at
+ *  *  * https://www.apache.org/licenses/LICENSE-2.0.
+ *  *  *
+ *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  *  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  *  * License for the specific language governing permissions and limitations
+ *  *  * under the License.
+ *  *  *
+ *  *  * SPDX-License-Identifier: Apache-2.0
+ *  *  *****************************************************************************
+ *
+ *
+ */
+
+public class Demo {
+}

--- a/dl4j-cv-labs/src/main/java/ai/certifai/training/object_detection/AvocadoBananaDetector/FruitDataSetIterator.java
+++ b/dl4j-cv-labs/src/main/java/ai/certifai/training/object_detection/AvocadoBananaDetector/FruitDataSetIterator.java
@@ -18,12 +18,12 @@
 package ai.certifai.training.object_detection.AvocadoBananaDetector;
 
 import ai.certifai.Helper;
+import ai.certifai.utilities.VocLabelProvider;
 import org.apache.commons.io.FileUtils;
 import org.datavec.api.split.FileSplit;
 import org.datavec.api.split.InputSplit;
 import org.datavec.image.loader.NativeImageLoader;
 import org.datavec.image.recordreader.objdetect.ObjectDetectionRecordReader;
-import org.datavec.image.recordreader.objdetect.impl.VocLabelProvider;
 import org.deeplearning4j.datasets.datavec.RecordReaderDataSetIterator;
 import org.nd4j.common.util.ArchiveUtils;
 import org.nd4j.linalg.dataset.api.preprocessor.ImagePreProcessingScaler;

--- a/dl4j-cv-labs/src/main/java/ai/certifai/training/object_detection/MetalDefectsDetector/MetalDefectDataSetIterator.java
+++ b/dl4j-cv-labs/src/main/java/ai/certifai/training/object_detection/MetalDefectsDetector/MetalDefectDataSetIterator.java
@@ -18,12 +18,12 @@
 package ai.certifai.training.object_detection.MetalDefectsDetector;
 
 import ai.certifai.Helper;
+import ai.certifai.utilities.VocLabelProvider;
 import org.apache.commons.io.FileUtils;
 import org.datavec.api.split.FileSplit;
 import org.datavec.api.split.InputSplit;
 import org.datavec.image.loader.NativeImageLoader;
 import org.datavec.image.recordreader.objdetect.ObjectDetectionRecordReader;
-import org.datavec.image.recordreader.objdetect.impl.VocLabelProvider;
 import org.deeplearning4j.datasets.datavec.RecordReaderDataSetIterator;
 import org.nd4j.common.util.ArchiveUtils;
 import org.nd4j.linalg.dataset.api.preprocessor.ImagePreProcessingScaler;

--- a/dl4j-cv-labs/src/main/java/ai/certifai/utilities/VocLabelProvider.java
+++ b/dl4j-cv-labs/src/main/java/ai/certifai/utilities/VocLabelProvider.java
@@ -38,7 +38,7 @@ public class VocLabelProvider implements ImageObjectLabelProvider {
         int idx = path.lastIndexOf('/');
         idx = Math.max(idx, path.lastIndexOf('\\'));
 
-        String filename = path.substring(idx+1, path.lastIndexOf('.'));   //-4: ".jpg"
+        String filename = path.substring(idx+1, path.lastIndexOf('.'));   // e.g. ".folder/folder/folder/image1.jpeg" -> "image1"
         String xmlPath = FilenameUtils.concat(annotationsDir, filename + ".xml");
         File xmlFile = new File(xmlPath);
         if(!xmlFile.exists()){

--- a/dl4j-cv-labs/src/main/java/ai/certifai/utilities/VocLabelProvider.java
+++ b/dl4j-cv-labs/src/main/java/ai/certifai/utilities/VocLabelProvider.java
@@ -1,0 +1,113 @@
+package ai.certifai.utilities;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.datavec.image.recordreader.objdetect.ImageObject;
+import org.datavec.image.recordreader.objdetect.ImageObjectLabelProvider;
+
+public class VocLabelProvider implements ImageObjectLabelProvider {
+    private static final String OBJECT_START_TAG = "<object>";
+    private static final String OBJECT_END_TAG = "</object>";
+    private static final String NAME_TAG = "<name>";
+    private static final String XMIN_TAG = "<xmin>";
+    private static final String YMIN_TAG = "<ymin>";
+    private static final String XMAX_TAG = "<xmax>";
+    private static final String YMAX_TAG = "<ymax>";
+    private String annotationsDir;
+
+    public VocLabelProvider(@NonNull String baseDirectory) {
+        if (baseDirectory == null) {
+            throw new NullPointerException("baseDirectory is marked non-null but is null");
+        } else {
+            this.annotationsDir = FilenameUtils.concat(baseDirectory, "Annotations");
+            if (!(new File(this.annotationsDir)).exists()) {
+                throw new IllegalStateException("Annotations directory does not exist. Annotation files should be present at baseDirectory/Annotations/nnnnnn.xml. Expected location: " + this.annotationsDir);
+            }
+        }
+    }
+
+    public List<ImageObject> getImageObjectsForPath(String path) {
+        int idx = path.lastIndexOf(47);
+        idx = Math.max(idx, path.lastIndexOf(92));
+        String filename = path.substring(idx + 1, path.length() - 4);
+        String xmlPath = FilenameUtils.concat(this.annotationsDir, filename + ".xml");
+        File xmlFile = new File(xmlPath);
+        if (!xmlFile.exists()) {
+            throw new IllegalStateException("Could not find XML file for image " + path + "; expected at " + xmlPath);
+        } else {
+            String xmlContent;
+            try {
+                xmlContent = FileUtils.readFileToString(xmlFile);
+            } catch (IOException var17) {
+                throw new RuntimeException(var17);
+            }
+
+            String[] lines = xmlContent.split("\n");
+            List<ImageObject> out = new ArrayList();
+
+            for(int i = 0; i < lines.length; ++i) {
+                if (lines[i].contains("<object>")) {
+                    String name = null;
+                    int xmin = -2147483648;
+                    int ymin = -2147483648;
+                    int xmax = -2147483648;
+                    int ymax = -2147483648;
+
+                    while(true) {
+                        while(!lines[i].contains("</object>")) {
+                            if (name == null && lines[i].contains("<name>")) {
+                                int idxStartName = lines[i].indexOf(62) + 1;
+                                int idxEndName = lines[i].lastIndexOf(60);
+                                name = lines[i].substring(idxStartName, idxEndName);
+                                ++i;
+                            } else if (xmin == -2147483648 && lines[i].contains("<xmin>")) {
+                                xmin = this.extractAndParse(lines[i]);
+                                ++i;
+                            } else if (ymin == -2147483648 && lines[i].contains("<ymin>")) {
+                                ymin = this.extractAndParse(lines[i]);
+                                ++i;
+                            } else if (xmax == -2147483648 && lines[i].contains("<xmax>")) {
+                                xmax = this.extractAndParse(lines[i]);
+                                ++i;
+                            } else if (ymax == -2147483648 && lines[i].contains("<ymax>")) {
+                                ymax = this.extractAndParse(lines[i]);
+                                ++i;
+                            } else {
+                                ++i;
+                            }
+                        }
+
+                        if (name == null) {
+                            throw new IllegalStateException("Invalid object format: no name tag found for object in file " + xmlPath);
+                        }
+
+                        if (xmin == -2147483648 || ymin == -2147483648 || xmax == -2147483648 || ymax == -2147483648) {
+                            throw new IllegalStateException("Invalid object format: did not find all of xmin/ymin/xmax/ymax tags in " + xmlPath);
+                        }
+
+                        out.add(new ImageObject(xmin, ymin, xmax, ymax, name));
+                        break;
+                    }
+                }
+            }
+
+            return out;
+        }
+    }
+
+    private int extractAndParse(String line) {
+        int idxStartName = line.indexOf(62) + 1;
+        int idxEndName = line.lastIndexOf(60);
+        String substring = line.substring(idxStartName, idxEndName);
+        return Integer.parseInt(substring);
+    }
+
+    public List<ImageObject> getImageObjectsForPath(URI uri) {
+        return this.getImageObjectsForPath(uri.toString());
+    }
+}

--- a/dl4j-cv-labs/src/main/java/ai/certifai/utilities/VocLabelProvider.java
+++ b/dl4j-cv-labs/src/main/java/ai/certifai/utilities/VocLabelProvider.java
@@ -44,7 +44,7 @@ public class VocLabelProvider implements ImageObjectLabelProvider {
         } else {
             String xmlContent;
             try {
-                xmlContent = FileUtils.readFileToString(xmlFile);
+                xmlContent = FileUtils.readFileToString(xmlFile, "UTF-8");
             } catch (IOException var17) {
                 throw new RuntimeException(var17);
             }

--- a/dl4j-cv-labs/src/main/java/ai/certifai/utilities/VocLabelProvider.java
+++ b/dl4j-cv-labs/src/main/java/ai/certifai/utilities/VocLabelProvider.java
@@ -5,6 +5,8 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+
+import lombok.NonNull;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.datavec.image.recordreader.objdetect.ImageObject;
@@ -32,9 +34,10 @@ public class VocLabelProvider implements ImageObjectLabelProvider {
     }
 
     public List<ImageObject> getImageObjectsForPath(String path) {
+        path = path.replaceAll("%20"," ");
         int idx = path.lastIndexOf(47);
         idx = Math.max(idx, path.lastIndexOf(92));
-        String filename = path.substring(idx + 1, path.length() - 4);
+        String filename = path.substring(idx + 1, path.lastIndexOf(46));
         String xmlPath = FilenameUtils.concat(this.annotationsDir, filename + ".xml");
         File xmlFile = new File(xmlPath);
         if (!xmlFile.exists()) {

--- a/dl4j-cv-labs/src/main/java/ai/certifai/utilities/VocLabelProvider.java
+++ b/dl4j-cv-labs/src/main/java/ai/certifai/utilities/VocLabelProvider.java
@@ -13,93 +13,115 @@ import org.datavec.image.recordreader.objdetect.ImageObject;
 import org.datavec.image.recordreader.objdetect.ImageObjectLabelProvider;
 
 public class VocLabelProvider implements ImageObjectLabelProvider {
+
+    private static final String OBJECT_START_TAG = "<object>";
+    private static final String OBJECT_END_TAG = "</object>";
+    private static final String NAME_TAG = "<name>";
+    private static final String XMIN_TAG = "<xmin>";
+    private static final String YMIN_TAG = "<ymin>";
+    private static final String XMAX_TAG = "<xmax>";
+    private static final String YMAX_TAG = "<ymax>";
+
     private String annotationsDir;
 
-    public VocLabelProvider(@NonNull String baseDirectory) {
+    public VocLabelProvider(@NonNull String baseDirectory){
         this.annotationsDir = FilenameUtils.concat(baseDirectory, "Annotations");
-        if (!(new File(this.annotationsDir)).exists())
-        {
-            throw new IllegalStateException("Annotations directory does not exist. Annotation files should be present at baseDirectory/Annotations/nnnnnn.xml. Expected location: " + this.annotationsDir);
+
+        if(!new File(annotationsDir).exists()){
+            throw new IllegalStateException("Annotations directory does not exist. Annotation files should be " +
+                    "present at baseDirectory/Annotations/nnnnnn.xml. Expected location: " + annotationsDir);
         }
     }
 
+    @Override
     public List<ImageObject> getImageObjectsForPath(String path) {
         int idx = path.lastIndexOf('/');
         idx = Math.max(idx, path.lastIndexOf('\\'));
-        String filename = path.substring(idx + 1, path.lastIndexOf('.'));
-        String xmlPath = FilenameUtils.concat(this.annotationsDir, filename + ".xml");
+
+        String filename = path.substring(idx+1, path.lastIndexOf('.'));   //-4: ".jpg"
+        String xmlPath = FilenameUtils.concat(annotationsDir, filename + ".xml");
         File xmlFile = new File(xmlPath);
-        if (!xmlFile.exists()) {
+        if(!xmlFile.exists()){
             throw new IllegalStateException("Could not find XML file for image " + path + "; expected at " + xmlPath);
-        } else {
-            String xmlContent;
-            try {
-                xmlContent = FileUtils.readFileToString(xmlFile, "UTF-8");
-            } catch (IOException var17) {
-                throw new RuntimeException(var17);
-            }
-
-            String[] lines = xmlContent.split("\n");
-            List<ImageObject> out = new ArrayList();
-
-            for(int i = 0; i < lines.length; ++i) {
-                if (lines[i].contains("<object>")) {
-                    String name = null;
-                    int xmin = -2147483648;
-                    int ymin = -2147483648;
-                    int xmax = -2147483648;
-                    int ymax = -2147483648;
-
-                    while(true) {
-                        while(!lines[i].contains("</object>")) {
-                            if (name == null && lines[i].contains("<name>")) {
-                                int idxStartName = lines[i].indexOf(62) + 1;
-                                int idxEndName = lines[i].lastIndexOf(60);
-                                name = lines[i].substring(idxStartName, idxEndName);
-                                ++i;
-                            } else if (xmin == -2147483648 && lines[i].contains("<xmin>")) {
-                                xmin = this.extractAndParse(lines[i]);
-                                ++i;
-                            } else if (ymin == -2147483648 && lines[i].contains("<ymin>")) {
-                                ymin = this.extractAndParse(lines[i]);
-                                ++i;
-                            } else if (xmax == -2147483648 && lines[i].contains("<xmax>")) {
-                                xmax = this.extractAndParse(lines[i]);
-                                ++i;
-                            } else if (ymax == -2147483648 && lines[i].contains("<ymax>")) {
-                                ymax = this.extractAndParse(lines[i]);
-                                ++i;
-                            } else {
-                                ++i;
-                            }
-                        }
-
-                        if (name == null) {
-                            throw new IllegalStateException("Invalid object format: no name tag found for object in file " + xmlPath);
-                        }
-
-                        if (xmin == -2147483648 || ymin == -2147483648 || xmax == -2147483648 || ymax == -2147483648) {
-                            throw new IllegalStateException("Invalid object format: did not find all of xmin/ymin/xmax/ymax tags in " + xmlPath);
-                        }
-
-                        out.add(new ImageObject(xmin, ymin, xmax, ymax, name));
-                        break;
-                    }
-                }
-            }
-
-            return out;
         }
+
+        String xmlContent;
+        try{
+            xmlContent = FileUtils.readFileToString(xmlFile, "UTF-8");
+        } catch (IOException e){
+            throw new RuntimeException(e);
+        }
+
+        //Normally we'd use Jackson to parse XML, but Jackson has real trouble with multiple XML elements with
+        //  the same name. However, the structure is simple and we can parse it manually (even though it's not
+        // the most elegant thing to do :)
+        String[] lines = xmlContent.split("\n");
+
+        List<ImageObject> out = new ArrayList<>();
+        for( int i=0; i<lines.length; i++ ){
+            if(!lines[i].contains(OBJECT_START_TAG)){
+                continue;
+            }
+            String name = null;
+            int xmin = Integer.MIN_VALUE;
+            int ymin = Integer.MIN_VALUE;
+            int xmax = Integer.MIN_VALUE;
+            int ymax = Integer.MIN_VALUE;
+            while(!lines[i].contains(OBJECT_END_TAG)){
+                if(name == null && lines[i].contains(NAME_TAG)){
+                    int idxStartName = lines[i].indexOf('>') + 1;
+                    int idxEndName = lines[i].lastIndexOf('<');
+                    name = lines[i].substring(idxStartName, idxEndName);
+                    i++;
+                    continue;
+                }
+                if(xmin == Integer.MIN_VALUE && lines[i].contains(XMIN_TAG)){
+                    xmin = extractAndParse(lines[i]);
+                    i++;
+                    continue;
+                }
+                if(ymin == Integer.MIN_VALUE && lines[i].contains(YMIN_TAG)){
+                    ymin = extractAndParse(lines[i]);
+                    i++;
+                    continue;
+                }
+                if(xmax == Integer.MIN_VALUE && lines[i].contains(XMAX_TAG)){
+                    xmax = extractAndParse(lines[i]);
+                    i++;
+                    continue;
+                }
+                if(ymax == Integer.MIN_VALUE && lines[i].contains(YMAX_TAG)){
+                    ymax = extractAndParse(lines[i]);
+                    i++;
+                    continue;
+                }
+
+                i++;
+            }
+
+            if(name == null){
+                throw new IllegalStateException("Invalid object format: no name tag found for object in file " + xmlPath);
+            }
+            if(xmin == Integer.MIN_VALUE || ymin == Integer.MIN_VALUE || xmax == Integer.MIN_VALUE || ymax == Integer.MIN_VALUE){
+                throw new IllegalStateException("Invalid object format: did not find all of xmin/ymin/xmax/ymax tags in " + xmlPath);
+            }
+
+            out.add(new ImageObject(xmin, ymin, xmax, ymax, name));
+        }
+
+        return out;
     }
 
-    private int extractAndParse(String line) {
+    private int extractAndParse(String line){
         int idxStartName = line.indexOf('>') + 1;
         int idxEndName = line.lastIndexOf('<');
         String substring = line.substring(idxStartName, idxEndName);
         return Integer.parseInt(substring);
     }
 
+    @Override
     public List<ImageObject> getImageObjectsForPath(URI uri) {
-        return this.getImageObjectsForPath(uri.toString());
+        return getImageObjectsForPath(uri.toString());
     }
+
 }

--- a/dl4j-cv-labs/src/main/java/ai/certifai/utilities/VocLabelProvider.java
+++ b/dl4j-cv-labs/src/main/java/ai/certifai/utilities/VocLabelProvider.java
@@ -34,7 +34,6 @@ public class VocLabelProvider implements ImageObjectLabelProvider {
     }
 
     public List<ImageObject> getImageObjectsForPath(String path) {
-        path = path.replaceAll("%20"," ");
         int idx = path.lastIndexOf(47);
         idx = Math.max(idx, path.lastIndexOf(92));
         String filename = path.substring(idx + 1, path.lastIndexOf(46));

--- a/dl4j-cv-labs/src/main/java/ai/certifai/utilities/VocLabelProvider.java
+++ b/dl4j-cv-labs/src/main/java/ai/certifai/utilities/VocLabelProvider.java
@@ -13,30 +13,20 @@ import org.datavec.image.recordreader.objdetect.ImageObject;
 import org.datavec.image.recordreader.objdetect.ImageObjectLabelProvider;
 
 public class VocLabelProvider implements ImageObjectLabelProvider {
-    private static final String OBJECT_START_TAG = "<object>";
-    private static final String OBJECT_END_TAG = "</object>";
-    private static final String NAME_TAG = "<name>";
-    private static final String XMIN_TAG = "<xmin>";
-    private static final String YMIN_TAG = "<ymin>";
-    private static final String XMAX_TAG = "<xmax>";
-    private static final String YMAX_TAG = "<ymax>";
     private String annotationsDir;
 
     public VocLabelProvider(@NonNull String baseDirectory) {
-        if (baseDirectory == null) {
-            throw new NullPointerException("baseDirectory is marked non-null but is null");
-        } else {
-            this.annotationsDir = FilenameUtils.concat(baseDirectory, "Annotations");
-            if (!(new File(this.annotationsDir)).exists()) {
-                throw new IllegalStateException("Annotations directory does not exist. Annotation files should be present at baseDirectory/Annotations/nnnnnn.xml. Expected location: " + this.annotationsDir);
-            }
+        this.annotationsDir = FilenameUtils.concat(baseDirectory, "Annotations");
+        if (!(new File(this.annotationsDir)).exists())
+        {
+            throw new IllegalStateException("Annotations directory does not exist. Annotation files should be present at baseDirectory/Annotations/nnnnnn.xml. Expected location: " + this.annotationsDir);
         }
     }
 
     public List<ImageObject> getImageObjectsForPath(String path) {
-        int idx = path.lastIndexOf(47);
-        idx = Math.max(idx, path.lastIndexOf(92));
-        String filename = path.substring(idx + 1, path.lastIndexOf(46));
+        int idx = path.lastIndexOf('/');
+        idx = Math.max(idx, path.lastIndexOf('\\'));
+        String filename = path.substring(idx + 1, path.lastIndexOf('.'));
         String xmlPath = FilenameUtils.concat(this.annotationsDir, filename + ".xml");
         File xmlFile = new File(xmlPath);
         if (!xmlFile.exists()) {
@@ -103,8 +93,8 @@ public class VocLabelProvider implements ImageObjectLabelProvider {
     }
 
     private int extractAndParse(String line) {
-        int idxStartName = line.indexOf(62) + 1;
-        int idxEndName = line.lastIndexOf(60);
+        int idxStartName = line.indexOf('>') + 1;
+        int idxEndName = line.lastIndexOf('<');
         String substring = line.substring(idxStartName, idxEndName);
         return Integer.parseInt(substring);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <exec-maven-plugin.version>1.4.0</exec-maven-plugin.version>
         <maven.minimum.version>3.3.1</maven.minimum.version>
         <javafx.version>2.2.3</javafx.version>
+        <lombok.version>1.18.16</lombok.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
## Description
Solving issue causing problem in reading filename for images.
In order to solve this issue, I just created a new class of VocLabelProvider, and modify some code based on the original code in dl4j library.
![image](https://user-images.githubusercontent.com/76682536/109817224-a1ee6700-7c6c-11eb-8cc2-c646a1568618.png)

1. In InputSplit class, locations of files are stored in URI format which " " is an invalid character, a common practice is replacing all the spaces with "%20". Therefore causing error while retrieving it to string. We could replace it back easily, but after some consideration, I decided to keep it. Reason being, there will still be some unstable condition when someone purposely provide file with name containing "%20". Rather we can enforce not to put space during file naming, as that is the good practice in the programming world. **Not Solve**
![image](https://user-images.githubusercontent.com/76682536/109826008-55f3f000-7c75-11eb-88c0-656eccb2d4bc.png)

2. previously image filename is just extracted by removing the last 4 characters. Now it replaced by finding the last '.' in the filename and remove all characters after that.
[Original code](https://github.com/eclipse/deeplearning4j/blob/master/datavec/datavec-data/datavec-data-image/src/main/java/org/datavec/image/recordreader/objdetect/impl/VocLabelProvider.java#L61)

